### PR TITLE
Update scripts for use jom on windows build

### DIFF
--- a/buildifw_qt5.sh
+++ b/buildifw_qt5.sh
@@ -182,7 +182,7 @@ if Not DEFINED ProgramFiles(x86) set _programs=%ProgramFiles%
 
 set QTDIR=$(win_path $OPT_QTDIR)
 set QMAKESPEC=$DEF_MSVC_SPEC
-set PATH=%PATH%;$(win_path $DEF_PREFIX)\invariant\bin
+set PATH=%PATH%;c:\invariant\jom;$(win_path $DEF_PREFIX)\invariant\bin
 
 call "%_programs%\Microsoft Visual Studio $DEF_MSVC_VER_ALT\VC\vcvarsall.bat"
 call %QTDIR%\qtbase\bin\qmake -r $(win_path $OPT_IFW_SRC_DIR)\installerfw.pro || exit 1

--- a/buildqmllive.sh
+++ b/buildqmllive.sh
@@ -311,7 +311,7 @@ if Not DEFINED ProgramFiles(x86) (
 set INSTALL_ROOT=$(win_path $QMLLIVE_INSTALL_ROOT)
 set QTDIR=$(win_path $OPT_QTDIR)\qtbase
 set QMAKESPEC=$DEF_MSVC_SPEC
-set PATH=%PATH%;%_programs%\7-zip;%QTDIR%\bin;$(win_path $DEF_PREFIX)\invariant\bin;c:\python27;$(win_path $OPT_ICU_PATH)\bin
+set PATH=%PATH%;c:\invariant\jom;%_programs%\7-zip;%QTDIR%\bin;$(win_path $DEF_PREFIX)\invariant\bin;c:\python27;$(win_path $OPT_ICU_PATH)\bin
 set INSTALLER_ARCHIVE=$SAILFISH_QMLLIVE_BASENAME$(build_arch).7z
 
 call rmdir /s /q $(win_path $QMLLIVE_INSTALL_ROOT)

--- a/buildqt5.sh
+++ b/buildqt5.sh
@@ -61,7 +61,7 @@ build_dynamic_qt_windows() {
 if DEFINED ProgramFiles(x86) set _programs=%ProgramFiles(x86)%
 if Not DEFINED ProgramFiles(x86) set _programs=%ProgramFiles%
 
-set PATH=c:\windows;c:\windows\system32;%_programs\windows kits\8.0\windows performance toolkit;%_programs%\7-zip;$(win_path $DEF_PREFIX)\invariant\bin;c:\python27;c:\perl\bin;c:\ruby193\bin;%_programs%\git\bin;$(win_path $DEF_ICU_INSTALL_DIR)\bin;$(win_path $DEF_QT_SRC_DIR)\gnuwin32\bin;%_programs%\microsoft sdks\typescript\1.0;c:\windows\system32\wbem;c:\windows\system32\windowspowershell\v1.0;$(win_path $DEF_PREFIX)\invariant\bin
+set PATH=c:\invariant\jom;c:\windows;c:\windows\system32;%_programs\windows kits\8.0\windows performance toolkit;%_programs%\7-zip;$(win_path $DEF_PREFIX)\invariant\bin;c:\python27;c:\perl\bin;c:\ruby193\bin;%_programs%\git\bin;$(win_path $DEF_ICU_INSTALL_DIR)\bin;$(win_path $DEF_QT_SRC_DIR)\gnuwin32\bin;%_programs%\microsoft sdks\typescript\1.0;c:\windows\system32\wbem;c:\windows\system32\windowspowershell\v1.0;$(win_path $DEF_PREFIX)\invariant\bin
 call "%_programs%\microsoft visual studio $DEF_MSVC_VER_ALT\vc\vcvarsall.bat"
 
 set MAKE=jom
@@ -115,7 +115,7 @@ build_static_qt_windows() {
 if DEFINED ProgramFiles(x86) set _programs=%ProgramFiles(x86)%
 if Not DEFINED ProgramFiles(x86) set _programs=%ProgramFiles%
 
-set PATH=c:\windows;c:\windows\system32;%_programs\windows kits\8.0\windows performance toolkit;%_programs%\7-zip;$(win_path $DEF_PREFIX)\invariant\bin;c:\python27;c:\perl\bin;c:\ruby193\bin;$(win_path $DEF_ICU_INSTALL_DIR)\bin;$(win_path $DEF_QT_SRC_DIR)\gnuwin32\bin;%_programs%\microsoft sdks\typescript\1.0;c:\windows\system32\wbem;c:\windows\system32\windowspowershell\v1.0;$(win_path $DEF_PREFIX)\invariant\bin
+set PATH=c:\invariant\jom;c:\windows;c:\windows\system32;%_programs\windows kits\8.0\windows performance toolkit;%_programs%\7-zip;$(win_path $DEF_PREFIX)\invariant\bin;c:\python27;c:\perl\bin;c:\ruby193\bin;$(win_path $DEF_ICU_INSTALL_DIR)\bin;$(win_path $DEF_QT_SRC_DIR)\gnuwin32\bin;%_programs%\microsoft sdks\typescript\1.0;c:\windows\system32\wbem;c:\windows\system32\windowspowershell\v1.0;$(win_path $DEF_PREFIX)\invariant\bin
 call "%_programs%\microsoft visual studio $DEF_MSVC_VER_ALT\vc\vcvarsall.bat" || exit 1
 
 set MAKE=jom

--- a/buildqtc.sh
+++ b/buildqtc.sh
@@ -385,20 +385,6 @@ build_windows_qtc() {
 	mkdir -p $QTC_BUILD_DIR
 	pushd    $QTC_BUILD_DIR
 
-	# fetch the binary artifacts if they can be found
-	#
-	# https://git.gitorious.org/qt-creator/binary-artifacts.git
-	#
-	local binary_artifacts="qtc-win32-binary-artifacts.7z"
-	echo "Downloading binary artifacts ..."
-	# Allow error code from curl
-	set +e
-	curl -s -f -o $binary_artifacts http://$OPT_UPLOAD_HOST/sailfishos/win32-binary-artifacts/$binary_artifacts
-	[[ $? -ne 0 ]] && echo "NOTE! Downloading binary artifacts failed [ignoring]"
-
-	# no more errors allowed
-	set -e
-
 	local opengl32sw_lib="opengl32sw-32.7z"
 	curl -s -f -o $opengl32sw_lib http://$OPT_UPLOAD_HOST/sailfishos/win32-binary-artifacts/opengl/$opengl32sw_lib
 
@@ -419,14 +405,10 @@ if Not DEFINED ProgramFiles(x86) (
 set INSTALL_ROOT=$(win_path $QTC_INSTALL_ROOT)
 set QTDIR=$(win_path $OPT_QTDIR)\qtbase
 set QMAKESPEC=$DEF_MSVC_SPEC
-set PATH=%PATH%;%_programs%\7-zip;%QTDIR%\bin;$(win_path $DEF_PREFIX)\invariant\bin;c:\python27;$(win_path $OPT_ICU_PATH)\bin
+set PATH=%PATH%;c:\invariant\jom;%_programs%\7-zip;%QTDIR%\bin;$(win_path $DEF_PREFIX)\invariant\bin;c:\python27;$(win_path $OPT_ICU_PATH)\bin
 set INSTALLER_ARCHIVE=$SAILFISH_QTC_BASENAME$(build_arch).7z
 
 call rmdir /s /q $(win_path $QTC_INSTALL_ROOT)
-
-if exist $binary_artifacts (
-  call 7z x -o$(win_path $QTC_INSTALL_ROOT) $binary_artifacts
-)
 
 call "%_programs%\microsoft visual studio $DEF_MSVC_VER_ALT\vc\vcvarsall.bat"
 


### PR DESCRIPTION
1. On build qt (static or dynamic) script can't find jom 
2. On build qt creator script try download binary artifacts and extract it to `QTC_INSTALL_ROOT`. However building now in `QTC_BUILD_DIR` and get error.

I want to change documentation to download jom to c:\invariant\jom and use this in all scripts