### PR TITLE
dnat-emulators: Use host.docker.internal if available. JB#49719

### DIFF
--- a/dnat-emulators
+++ b/dnat-emulators
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# This file is part of Sailfish SDK
+#
+# Copyright (C) 2020 Open Mobile Platform LLC.
+# Contact: Ville Nummela <ville.nummela@jolla.com>
+# All rights reserved.
+#
+# You may use this file under the terms of BSD license as follows:
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#   * Neither the name of the Jolla Ltd nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+DEF_EMULATOR_IP=172.17.0.1
+
+EMULATOR_IP=$(getent hosts host.docker.internal |awk '{ print $1 }')
+
+if [[ ! $EMULATOR_IP ]]; then
+    EMULATOR_IP=$DEF_EMULATOR_IP
+fi
+
+# FIXME breaks when the port is later changed by user
+for ((i=0; i<10; i++)); do
+    iptables -t nat -A OUTPUT -p tcp -d 10.220.220.$((1+i)) --dport 22 -j DNAT \
+        --to-destination $EMULATOR_IP:$((2223+i))
+done

--- a/dnat-emulators.service
+++ b/dnat-emulators.service
@@ -6,8 +6,7 @@ Description=Set up DNAT to enable access to Sailfish OS Emulators
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-# FIXME breaks when the port is later changed by user
-ExecStart=/bin/bash -c "for ((i=0; i<10; i++)); do iptables -t nat -A OUTPUT -p tcp -d 10.220.220.$((1+i)) --dport 22 -j DNAT --to-destination 172.17.0.1:$((2223+i)); done"
+ExecStart=/usr/libexec/sdk-setup/dnat-emulators
 
 [Install]
 WantedBy=multi-user.target

--- a/setup-buildengine.sh
+++ b/setup-buildengine.sh
@@ -3,7 +3,7 @@
 # SDK build engine creation script
 #
 # Copyright (C) 2014-2019 Jolla Oy
-# Copyright (C) 2019 Open Mobile Platform LLC.
+# Copyright (C) 2019-2020 Open Mobile Platform LLC.
 # Contact: Ville Nummela <ville.nummela@jolla.com>
 # All rights reserved.
 #
@@ -197,6 +197,9 @@ createTar() {
     sudo rm mer.d/lib/systemd/system/basic.target.wants/!(dbus.service)
 
     echo "Setting up DNAT to enable access to emulators ..."
+    mkdir -p mer.d/usr/libexec/sdk-setup
+    sudo cp $(dirname $0)/dnat-emulators mer.d/usr/libexec/sdk-setup/dnat-emulators
+    chmod a+x mer.d/usr/libexec/sdk-setup/dnat-emulators
     sudo cp $(dirname $0)/dnat-emulators.service mer.d/etc/systemd/system/
     sudo ln -s /etc/systemd/system/dnat-emulators.service mer.d/etc/systemd/system/multi-user.target.wants/
 


### PR DESCRIPTION
When run under Windows, docker provides access to host using hostname
host.docker.internal instead of the usual IP address