### PR TITLE
setup-buildengine: Add connman-config to docker image. JB#49302

### DIFF
--- a/connman-config
+++ b/connman-config
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# This file is part of Sailfish SDK
+#
+# Copyright (C) 2020 Open Mobile Platform LLC.
+# Contact: Ville Nummela <ville.nummela@jolla.com>
+# All rights reserved.
+#
+# You may use this file under the terms of BSD license as follows:
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#   * Neither the name of the Jolla Ltd nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+MAC=$(cat /sys/class/net/eth?/address | sed 's/://g')
+
+SERVICE="ethernet_${MAC}_cable"
+SERVICE_DIR="/var/lib/connman/${SERVICE}"
+SERVICE_FILE=${SERVICE_DIR}/settings
+
+IP_ADDR=$(hostname -i)
+
+GATEWAY=$(ip r | awk '/default/{ print $3 }')
+NAMESERVERS=$(awk '/^nameserver/{ printf "%s;",$2 }' /etc/resolv.conf)
+DATE=$(date -u +%Y-%m-%dT%H:%M:%S.%NZ)
+
+if [[ -d "${SERVICE_DIR}" ]]; then
+    sed -i -e "s/IPv4.local_address=.*/IPv4.local_address=${IP_ADDR}/" ${SERVICE_FILE}
+else
+    mkdir -p ${SERVICE_DIR}
+    cat <<EOF > ${SERVICE_FILE}
+[${SERVICE}]
+Name=Wired
+AutoConnect=true
+Modified=${DATE}
+IPv4.method=manual
+IPv4.netmask_prefixlen=16
+IPv4.local_address=${IP_ADDR}
+IPv4.gateway=${GATEWAY}
+IPv6.method=auto
+IPv6.privacy=disabled
+Nameservers=${NAMESERVERS}
+EOF
+fi

--- a/connman-config.service
+++ b/connman-config.service
@@ -1,0 +1,13 @@
+# This file is part of Sailfish SDK
+
+[Unit]
+Description=Configure Connman so that it can be used with Sailfish Build Engine
+Before=connman.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/libexec/sdk-setup/connman-config
+
+[Install]
+WantedBy=multi-user.target

--- a/setup-buildengine.sh
+++ b/setup-buildengine.sh
@@ -190,7 +190,7 @@ createTar() {
 
     echo "Disabling unneeded systemd services ..."
     sudo rm mer.d/lib/systemd/system/sysinit.target.wants/*
-    sudo rm mer.d/lib/systemd/system/multi-user.target.wants/!(sshd-keys.service|sshd.socket)
+    sudo rm mer.d/lib/systemd/system/multi-user.target.wants/!(sshd-keys.service|sshd.socket|network.target)
     sudo rm mer.d/etc/systemd/system/basic.target.wants/*
     sudo rm mer.d/etc/systemd/system/multi-user.target.wants/!(sdk-webapp.service)
     sudo rm mer.d/lib/systemd/system/sockets.target.wants/!(dbus.socket)
@@ -202,6 +202,12 @@ createTar() {
     sudo chmod a+x mer.d/usr/libexec/sdk-setup/dnat-emulators
     sudo cp $(dirname $0)/dnat-emulators.service mer.d/etc/systemd/system/
     sudo ln -s /etc/systemd/system/dnat-emulators.service mer.d/etc/systemd/system/multi-user.target.wants/
+
+    echo "Setting up connman configuration ..."
+    sudo cp $(dirname $0)/connman-config mer.d/usr/libexec/sdk-setup/connman-config
+    sudo chmod a+x mer.d/usr/libexec/sdk-setup/connman-config
+    sudo cp $(dirname $0)/connman-config.service mer.d/etc/systemd/system/
+    sudo ln -s /etc/systemd/system/connman-config.service mer.d/etc/systemd/system/multi-user.target.wants/
 
     echo "Changing permissions of /srv/mer ..."
     sudo chmod -R a+rwX mer.d/srv/mer


### PR DESCRIPTION
As docker already configures network, we must configure connman so that
the configuration matches