### PR TITLE
buildqtc.sh: Always copy msvc*100.dll from system32 dir. JB#50746

### DIFF
--- a/buildqtc.sh
+++ b/buildqtc.sh
@@ -432,13 +432,13 @@ build_windows_qtc() {
 	cat <<EOF > build-windows.bat
 @echo off
 
+set _systemdir=%windir%\system32
+
 if DEFINED ProgramFiles(x86) (
     set "_programs=%ProgramFiles(x86)%"
-    set _systemdir=%windir%\system
 )
 if Not DEFINED ProgramFiles(x86) (
     set _programs=%ProgramFiles%
-    set _systemdir=%windir%\system32
 )
 
 


### PR DESCRIPTION
The old logic for copying the dlls was flawed: Even on 64bit systems
the dlls are in C:\Windows\system32 and not in C:\Windows\system