### PR TITLE
buildqt5.sh: Remove call to old vcvarsall.bat

### DIFF
--- a/buildllvm.sh
+++ b/buildllvm.sh
@@ -44,7 +44,12 @@ export LC_ALL=C
 
 configure_llvm() {
     # See Qt Creator's README
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$DEF_LLVM_INSTALL_DIR -DLLVM_ENABLE_RTTI=ON $DEF_LLVM_SRC_DIR
+    cmake \
+        -D CMAKE_BUILD_TYPE=Release \
+        -D LLVM_ENABLE_RTTI=ON \
+        -D LLVM_ENABLE_PROJECTS="clang;clang-tools-extra" \
+        -D CMAKE_INSTALL_PREFIX=$DEF_LLVM_INSTALL_DIR \
+        $DEF_LLVM_SRC_DIR/llvm
 }
 
 build_llvm() {

--- a/buildqt5.sh
+++ b/buildqt5.sh
@@ -118,7 +118,6 @@ if DEFINED ProgramFiles(x86) set _programs=%ProgramFiles(x86)%
 if Not DEFINED ProgramFiles(x86) set _programs=%ProgramFiles%
 
 set PATH=c:\windows;c:\windows\system32;%_programs\windows kits\8.0\windows performance toolkit;%_programs%\7-zip;$(win_path $DEF_PREFIX)\invariant\bin;c:\python27;c:\perl\bin;c:\ruby193\bin;$(win_path $DEF_ICU_INSTALL_DIR)\bin;$(win_path $DEF_QT_SRC_DIR)\gnuwin32\bin;%_programs%\microsoft sdks\typescript\1.0;c:\windows\system32\wbem;c:\windows\system32\windowspowershell\v1.0;$(win_path $DEF_PREFIX)\invariant\bin
-call "%_programs%\microsoft visual studio $DEF_MSVC_VER_ALT\vc\vcvarsall.bat" || exit 1
 call "%_programs%\Microsoft Visual Studio\\$DEF_MSVC_VER\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86 || exit 1
 
 set MAKE=jom

--- a/buildqt5.sh
+++ b/buildqt5.sh
@@ -64,7 +64,7 @@ if DEFINED ProgramFiles(x86) set _programs=%ProgramFiles(x86)%
 if Not DEFINED ProgramFiles(x86) set _programs=%ProgramFiles%
 
 set PATH=c:\windows;c:\windows\system32;%_programs\windows kits\8.0\windows performance toolkit;%_programs%\7-zip;$(win_path $DEF_PREFIX)\invariant\bin;c:\python27;c:\perl\bin;c:\ruby193\bin;%_programs%\git\bin;$(win_path $DEF_ICU_INSTALL_DIR)\bin;$(win_path $DEF_QT_SRC_DIR)\gnuwin32\bin;%_programs%\microsoft sdks\typescript\1.0;c:\windows\system32\wbem;c:\windows\system32\windowspowershell\v1.0;$(win_path $DEF_PREFIX)\invariant\bin
-call "%_programs%\microsoft visual studio $DEF_MSVC_VER_ALT\vc\vcvarsall.bat"
+call "%_programs%\Microsoft Visual Studio\\$DEF_MSVC_VER\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86 || exit 1
 
 set MAKE=jom
 call $(win_path $DEF_QT_SRC_DIR)\configure.bat -make-tool jom $COMMON_CONFIG_OPTIONS -no-dbus -skip qtwebengine -icu -I $(win_path $DEF_ICU_INSTALL_DIR)\include -L $(win_path $DEF_ICU_INSTALL_DIR)\lib -opengl dynamic -platform $DEF_MSVC_SPEC -prefix "%CD%/qtbase" || exit 1
@@ -119,6 +119,7 @@ if Not DEFINED ProgramFiles(x86) set _programs=%ProgramFiles%
 
 set PATH=c:\windows;c:\windows\system32;%_programs\windows kits\8.0\windows performance toolkit;%_programs%\7-zip;$(win_path $DEF_PREFIX)\invariant\bin;c:\python27;c:\perl\bin;c:\ruby193\bin;$(win_path $DEF_ICU_INSTALL_DIR)\bin;$(win_path $DEF_QT_SRC_DIR)\gnuwin32\bin;%_programs%\microsoft sdks\typescript\1.0;c:\windows\system32\wbem;c:\windows\system32\windowspowershell\v1.0;$(win_path $DEF_PREFIX)\invariant\bin
 call "%_programs%\microsoft visual studio $DEF_MSVC_VER_ALT\vc\vcvarsall.bat" || exit 1
+call "%_programs%\Microsoft Visual Studio\\$DEF_MSVC_VER\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86 || exit 1
 
 set MAKE=jom
 call $(win_path $DEF_QT_SRC_DIR)\configure.bat -make-tool jom $COMMON_CONFIG_OPTIONS $COMMON_STATIC_OPTIONS -angle -platform $DEF_MSVC_SPEC -static-runtime -prefix "%CD%/qtbase" || exit 1

--- a/buildqtc.sh
+++ b/buildqtc.sh
@@ -432,13 +432,13 @@ build_windows_qtc() {
 	cat <<EOF > build-windows.bat
 @echo off
 
+set _systemdir=%windir%\system32
+
 if DEFINED ProgramFiles(x86) (
     set "_programs=%ProgramFiles(x86)%"
-    set _systemdir=%windir%\system
 )
 if Not DEFINED ProgramFiles(x86) (
     set _programs=%ProgramFiles%
-    set _systemdir=%windir%\system32
 )
 
 

--- a/buildqtc.sh
+++ b/buildqtc.sh
@@ -455,7 +455,7 @@ if exist $binary_artifacts (
   call 7z x -o$(win_path $QTC_INSTALL_ROOT) $binary_artifacts
 )
 
-call "%_programs%\microsoft visual studio $DEF_MSVC_VER_ALT\vc\vcvarsall.bat"
+call "%_programs%\Microsoft Visual Studio\\$DEF_MSVC_VER\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86
 
 call %QTDIR%\bin\qmake $(win_path $OPT_QTC_SRC_DIR)\qtcreator.pro CONFIG+=release -r ^
     QTC_SHOW_BUILD_DATE=1 ^
@@ -476,8 +476,8 @@ call 7z x -o%INSTALL_ROOT%\bin $opengl32sw_lib
 for %%i in ($pkg_config_libs) do (
     call 7z x -o%INSTALL_ROOT% %%i < NUL || exit 1
 )
-copy "%_programs%\microsoft visual studio $DEF_MSVC_VER_ALT\vc\bin\D3Dcompiler_*.dll" %INSTALL_ROOT%\bin || exit 1
-pushd "%_programs%\microsoft visual studio $DEF_MSVC_VER_ALT\vc\redist\x86\microsoft.vc*.crt" ^
+copy "%VCToolsInstallDir%\bin\Hostx86\x86\d3dcompiler_*.dll" %INSTALL_ROOT%\bin || exit 1
+pushd "%VCToolsRedistDir%\x86\Microsoft.VC*.CRT" ^
     && copy "*.dll" %INSTALL_ROOT%\bin ^
     && popd || exit 1
 copy "%_systemdir%\msvc*100.dll" %INSTALL_ROOT%\bin || exit 1

--- a/defaults.sh
+++ b/defaults.sh
@@ -50,10 +50,10 @@
 DEF_WIN_ICU_DOWNLOAD_URL="$DEF_URL_PREFIX/win32-binary-artifacts/icu/icu4c-4_8_1_1-Win32-msvc10.zip"
 
 # The download URL for the Windows LLVM/Clang binaries
-DEF_WIN_LLVM_DOWNLOAD_URL="$DEF_URL_PREFIX/win32-binary-artifacts/llvm/libclang-release_70-based-windows-vs2015_32.7z"
+DEF_WIN_LLVM_DOWNLOAD_URL="$DEF_URL_PREFIX/win32-binary-artifacts/llvm/libclang-release_80-based-windows-vs2017_32.7z"
 
 # The download URL for the macOS LLVM/Clang binaries
-DEF_MAC_LLVM_DOWNLOAD_URL="$DEF_URL_PREFIX/mac-binary-artifacts/llvm/libclang-release_70-based-mac.7z"
+DEF_MAC_LLVM_DOWNLOAD_URL="$DEF_URL_PREFIX/mac-binary-artifacts/llvm/libclang-release_80-based-mac.7z"
 
 # The Qt version to use
 DEF_QT_VER=5.12.5

--- a/defaults.sh
+++ b/defaults.sh
@@ -59,8 +59,8 @@ DEF_MAC_LLVM_DOWNLOAD_URL="$DEF_URL_PREFIX/mac-binary-artifacts/llvm/libclang-re
 DEF_QT_VER=5.12.5
 
 # The Microsoft Visual C++ version to use
-DEF_MSVC_VER=2015
-DEF_MSVC_VER_ALT=14.0
+DEF_MSVC_VER=2019
+DEF_MSVC_VER_ALT=16.7.1
 DEF_MSVC_SPEC=win32-msvc
 
 # The default release version
@@ -125,9 +125,11 @@ if [[ $UNAME_SYSTEM == "Linux" ]] || [[ $UNAME_SYSTEM == "Darwin" ]]; then
     DEF_QT_STATIC_BUILD_DIR=$DEF_PREFIX/invariant/$DEF_QT_SOURCE_PACKAGE-static-build
 else
     # Dynamic Qt build directory on Windows
-    DEF_QT_DYN_BUILD_DIR=$DEF_PREFIX/invariant/$DEF_QT_SOURCE_PACKAGE-build-msvc$DEF_MSVC_VER
+    # DEF_QT_DYN_BUILD_DIR=$DEF_PREFIX/invariant/$DEF_QT_SOURCE_PACKAGE-build-msvc$DEF_MSVC_VER
+    DEF_QT_DYN_BUILD_DIR=$DEF_PREFIX/invariant/$DEF_QT_SOURCE_PACKAGE-build-msvc2015
     # Static Qt build directory on Windows
-    DEF_QT_STATIC_BUILD_DIR=$DEF_PREFIX/invariant/$DEF_QT_SOURCE_PACKAGE-static-build-msvc$DEF_MSVC_VER
+    # DEF_QT_STATIC_BUILD_DIR=$DEF_PREFIX/invariant/$DEF_QT_SOURCE_PACKAGE-static-build-msvc$DEF_MSVC_VER
+    DEF_QT_STATIC_BUILD_DIR=$DEF_PREFIX/invariant/$DEF_QT_SOURCE_PACKAGE-static-build-msvc2015
 fi
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
Call to vcvarsall.bat in the old location was accidentally left when
upgrading to Visual Studio 2019